### PR TITLE
Update init-script with lsb init functions

### DIFF
--- a/iptables-persistent
+++ b/iptables-persistent
@@ -21,8 +21,6 @@ rc=0
 
 case "$1" in
 start)
-    log_action_begin_msg "Starting iptables"
-
     if [ -e /var/run/iptables ]; then
         log_warning_msg "iptables is already started!"
         exit 1
@@ -35,6 +33,8 @@ start)
         /etc/init.d/fail2ban stop
     fi
 
+    log_action_begin_msg "Starting iptables"
+
     if [ $ENABLE_ROUTING -ne 0 ]; then
         # Enable Routing
         echo 1 > /proc/sys/net/ipv4/ip_forward
@@ -45,10 +45,10 @@ start)
         fi
     fi
 
-    if [ $MODULES ]; then
+    if [ $modules ]; then
         # Load Modules
-        modprobe -a $MODULES
-        log_action_cont_msg "Modules $MODULES"
+        modprobe -a $modules
+        log_action_cont_msg "Modules $modules"
     fi
 
     # Load saved rules
@@ -66,24 +66,24 @@ start)
         fi
         log_action_cont_msg "IPv6"
     fi
- 
+
+    log_action_end_msg $rc
+
     # restart of fail2ban
     if [ -x /etc/init.d/fail2ban ]; then
         /etc/init.d/fail2ban start
     fi
-
-    log_action_end_msg $rc
     ;;
 
 stop|force-stop)
-    log_action_begin_msg "Stopping iptables"
-
     if [ ! -e /var/run/iptables ]; then
         log_warning_msg "iptables is already stopped!"
         exit 1
     else
         rm /var/run/iptables
     fi
+
+    log_action_begin_msg "Stopping iptables"
 
     if [ $SAVE_NEW_RULES -ne 0 ]; then
         # Backup old rules
@@ -106,6 +106,8 @@ stop|force-stop)
             log_action_cont_msg "IPv6"
         fi
     fi
+
+    log_action_end_msg $rc
 
     # stop fail2ban before flushing iptables chains
     if [ -x /etc/init.d/fail2ban ]; then
@@ -133,9 +135,9 @@ stop|force-stop)
         ip6tables -t mangle -F
     fi
 
-    if [ $MODULES ]; then
+    if [ $modules ]; then
         # Unload previously loaded modules
-        modprobe -r $MODULES
+        modprobe -r $modules
     fi
 
     # Disable Routing if enabled
@@ -151,8 +153,6 @@ stop|force-stop)
     if [ -x /etc/init.d/fail2ban ]; then
         /etc/init.d/fail2ban start
     fi
-
-    log_action_end_msg $rc
     ;;
 
 restart|force-reload)


### PR DESCRIPTION
I borrowed the LSB headers from Ubuntu's apt-provided init script, added return code checks on calls to `iptables-restore` & `iptables-save`, and replaced most `echo` calls with the lsb logging functions.
